### PR TITLE
Implement `DiagonalEK0`, an EK0 with vector-valued diffusion

### DIFF
--- a/tests/test_ek0.py
+++ b/tests/test_ek0.py
@@ -51,6 +51,7 @@ def scipy_solution(ivp):
 EK0_VERSIONS = [
     tornadox.ek0.ReferenceEK0,
     tornadox.ek0.KroneckerEK0,
+    tornadox.ek0.DiagonalEK0,
 ]
 all_ek0_versions = pytest.mark.parametrize("ek0_version", EK0_VERSIONS)
 


### PR DESCRIPTION
Resolves #79

The PR contains an implementation of an EK0 with vector-valued diffusion. I just copied over the `DiagonalEK1` and removed all mentions of the Jacobian. The solver therefore builds on the `BatchedEK1`.