### PR TITLE
Add sanity check: `assert dt >= 0`

### DIFF
--- a/tornadox/odefilter.py
+++ b/tornadox/odefilter.py
@@ -170,6 +170,8 @@ class ODEFilter(ABC):
             else:
                 dt = min(suggested_dt, state.ivp.tmax - state.t)
 
+            assert dt >= 0, f"Invalid step size: dt={dt}"
+
         return proposed_state, dt, step_info
 
     @abstractmethod


### PR DESCRIPTION
I waited for quite a while trying to solve `fhn_2d` with a `DiagonalEK0`. It turns out the step-size became NaN! This check should make sure to raise an error if this happens.