### PR TITLE
Add more jitting to the KroneckerEK0

### DIFF
--- a/tornadox/sqrt.py
+++ b/tornadox/sqrt.py
@@ -5,12 +5,14 @@ import jax.numpy as jnp
 import jax.scipy.linalg
 
 
+@jax.jit
 def propagate_cholesky_factor(S1, S2):
     """Compute Cholesky factor of A @ SC @ SC.T @ A.T + SQ @ SQ.T"""
     stacked_up = jnp.vstack((S1.T, S2.T))
     return sqrtm_to_cholesky(stacked_up)
 
 
+@jax.jit
 def sqrtm_to_cholesky(St):
     """Assume that St=S^\top is a 'right' matrix-square-root.
 


### PR DESCRIPTION
Makes a HUGE difference! Without this solving `fhn_2d` takes many hours (or even days?). With this, it's 45 minutes :) 

Though this is not actually sufficient to solve the problem since `odefilter.py` assembles the full, dense covariance matrix. I might add a fix to this (in my code I currenlty just save the Kronecker factors, but that can probably be done more nicely).