### PR TITLE
Do not save the dxd left kronecker factor in the KroneckerEK0 

### DIFF
--- a/tests/test_ek0.py
+++ b/tests/test_ek0.py
@@ -123,7 +123,7 @@ def stepped_both(solver_tuple, ivp, initialized_both):
 
 def test_init_type(initialized_both):
     kronecker_init, _ = initialized_both
-    assert isinstance(kronecker_init.y, tornadox.rv.EK0SpecializedMatrixNormal)
+    assert isinstance(kronecker_init.y, tornadox.rv.LeftIsotropicMatrixNormal)
 
 
 def test_init_values(initialized_both, d):
@@ -187,7 +187,7 @@ def stepped_reference(stepped_both):
 
 
 def test_attempt_step_y_type(stepped_kronecker):
-    assert isinstance(stepped_kronecker.y, tornadox.rv.EK0SpecializedMatrixNormal)
+    assert isinstance(stepped_kronecker.y, tornadox.rv.LeftIsotropicMatrixNormal)
 
 
 def test_attempt_step_y_shapes_kronecker(stepped_kronecker, d, num_derivatives):

--- a/tests/test_rv.py
+++ b/tests/test_rv.py
@@ -161,17 +161,17 @@ class TestMatrixNormal:
         assert type(out) == type(matrix_normal)
 
 
-class TestEK0SpecializedMatrixNormal:
+class TestLeftIsotropicMatrixNormal:
     @staticmethod
     @pytest.fixture
     def ek0_matrix_normal(mean, dimension, cov_sqrtm):
-        return tornadox.rv.EK0SpecializedMatrixNormal(
+        return tornadox.rv.LeftIsotropicMatrixNormal(
             mean=mean, d=dimension, cov_sqrtm_2=cov_sqrtm
         )
 
     @staticmethod
     def test_type(ek0_matrix_normal):
-        assert isinstance(ek0_matrix_normal, tornadox.rv.EK0SpecializedMatrixNormal)
+        assert isinstance(ek0_matrix_normal, tornadox.rv.LeftIsotropicMatrixNormal)
 
     @staticmethod
     def test_cov_1_values(ek0_matrix_normal):
@@ -201,7 +201,7 @@ class TestEK0SpecializedMatrixNormal:
     def test_jittable(ek0_matrix_normal):
         def fun(rv):
             m, d, sc2 = rv
-            return tornadox.rv.EK0SpecializedMatrixNormal(2 * m, 2 * d, 2 * sc2)
+            return tornadox.rv.LeftIsotropicMatrixNormal(2 * m, 2 * d, 2 * sc2)
 
         fun_jitted = jax.jit(fun)
         out = fun_jitted(ek0_matrix_normal)

--- a/tornadox/ek0.py
+++ b/tornadox/ek0.py
@@ -112,7 +112,7 @@ class KroneckerEK0(odefilter.ODEFilter):
         self.e0 = self.iwp.projection_matrix_1d(0)
         self.e1 = self.iwp.projection_matrix_1d(1)
 
-        y = rv.EK0SpecializedMatrixNormal(mean=mean, d=d, cov_sqrtm_2=cov_sqrtm)
+        y = rv.LeftIsotropicMatrixNormal(mean=mean, d=d, cov_sqrtm_2=cov_sqrtm)
 
         return odefilter.ODEFilterState(
             ivp=ivp,
@@ -190,7 +190,7 @@ class KroneckerEK0(odefilter.ODEFilter):
             t=t_new,
             error_estimate=error_estimate,
             reference_state=y_new,
-            y=rv.EK0SpecializedMatrixNormal(_m_new, state.y.d, _Cl_new),
+            y=rv.LeftIsotropicMatrixNormal(_m_new, state.y.d, _Cl_new),
         )
         info_dict = dict(num_f_evaluations=1)
         return new_state, info_dict
@@ -258,6 +258,7 @@ class DiagonalEK0(BatchedEK1):
         h_sc_bd = sc_bd_no_precon_1  # shape (d,n)
 
         s = jnp.einsum("dn,dn->d", h_sc_bd, h_sc_bd)  # shape (d,)
+        s += 1e-16
         cross = sc_bd @ h_sc_bd[..., None]  # shape (d,n,1)
         kgain = cross / s[..., None, None]  # shape (d,n,1)
 

--- a/tornadox/ek1.py
+++ b/tornadox/ek1.py
@@ -288,6 +288,7 @@ class DiagonalEK1(BatchedEK1):
         )  # shape (d,n)
 
         s = jnp.einsum("dn,dn->d", h_sc_bd, h_sc_bd)  # shape (d,)
+        s += 1e-16
         cross = sc_bd @ h_sc_bd[..., None]  # shape (d,n,1)
         kgain = cross / s[..., None, None]  # shape (d,n,1)
 

--- a/tornadox/rv.py
+++ b/tornadox/rv.py
@@ -42,8 +42,8 @@ class MatrixNormal(namedtuple("_MatrixNormal", "mean cov_sqrtm_1 cov_sqrtm_2")):
         return jnp.kron(self.cov_sqrtm_1, self.cov_sqrtm_2)
 
 
-class EK0SpecializedMatrixNormal(
-    namedtuple("_EK0SpecializedMatrixNormal", "mean d cov_sqrtm_2")
+class LeftIsotropicMatrixNormal(
+    namedtuple("_LeftIsotropicMatrixNormal", "mean d cov_sqrtm_2")
 ):
     """Matrixvariate normal distributions as they appear in the EK0
 


### PR DESCRIPTION
My approach was to implement an `EK0SpecializedMatrixNormal` that "knows" about the fact that the left Kronecker factor is always a d-dimensional identity matrix. This way, I only save `d`, not `jnp.eye(d)`.

This PR resolves an issue mentioned in #100. Now, we should not have a `O(d^2)` memory scaling anymore :)

What this does however not resolve is how to properly store these in the `ODESolution` object. If I figure that out we might not need the `save_covariances=False` option anymore. One approach might be to move away from special normal distributions, and towards covariance-matrix objects? E.g. `KroneckerCovariance`, and `BlockDiagonalCovariance`, and save these objects instead of calling their `cov`. Let me know what you think @pnkraemer.