### PR TITLE
Enable scalar error estimates and use them in the KroneckerEK0

### DIFF
--- a/tests/test_ek0.py
+++ b/tests/test_ek0.py
@@ -214,7 +214,7 @@ def test_attempt_step_y_shapes_reference(stepped_reference, d, num_derivatives):
 def test_attempt_step_error_estimate_kronecker(stepped_kronecker, d):
 
     assert isinstance(stepped_kronecker.error_estimate, jnp.ndarray)
-    assert stepped_kronecker.error_estimate.shape == (d,)
+    assert stepped_kronecker.error_estimate.shape == ()
     assert jnp.all(stepped_kronecker.error_estimate >= 0)
 
 

--- a/tornadox/ek0.py
+++ b/tornadox/ek0.py
@@ -128,7 +128,7 @@ class KroneckerEK0(odefilter.ODEFilter):
     def compute_sigmasquared_error(P, Ql, z):
         HQH = (P @ Ql @ Ql.T @ P.T)[1, 1]
         sigma_squared = z.T @ z / HQH / z.shape[0]
-        error_estimate = jnp.stack([jnp.sqrt(sigma_squared * HQH)] * z.shape[0])
+        error_estimate = jnp.sqrt(sigma_squared * HQH)
         return sigma_squared, error_estimate
 
     @staticmethod

--- a/tornadox/step.py
+++ b/tornadox/step.py
@@ -93,7 +93,9 @@ class AdaptiveSteps(StepRule):
         return scaled_error_estimate < 1
 
     def scale_error_estimate(self, unscaled_error_estimate, reference_state):
-        if unscaled_error_estimate.shape != reference_state.shape:
+        if (
+            not jnp.isscalar(unscaled_error_estimate.size)
+        ) and unscaled_error_estimate.shape != reference_state.shape:
             raise ValueError(
                 "Unscaled error estimate needs same shape as reference state."
             )


### PR DESCRIPTION
Removing the `jnp.stack(...)` part greatly improves the jax jit compilation times! 