### PR TITLE
ImportError Fixed: Use jax.config.update and remove import .__version

### DIFF
--- a/tornadox/__init__.py
+++ b/tornadox/__init__.py
@@ -1,10 +1,8 @@
 """Collect all modules into the tornadox.* namespace"""
 
-from jax.config import config
+import jax
 
 from . import ek0, ek1, experimental, init, ivp, iwp, kalman, odefilter, rv, sqrt, step
 
-config.update("jax_enable_x64", True)
+jax.config.update("jax_enable_x64", True)
 
-
-from ._version import version as __version__

--- a/tornadox/__init__.py
+++ b/tornadox/__init__.py
@@ -6,3 +6,5 @@ from . import ek0, ek1, experimental, init, ivp, iwp, kalman, odefilter, rv, sqr
 
 jax.config.update("jax_enable_x64", True)
 
+
+from ._version import version as __version__


### PR DESCRIPTION
Hello Nico and contributors of tornadox,

Thanks for sharing your work! 

When importing your package, I found two issues that cause import error: (1) Importing `jax.config` is deprecated in newer Jax (2) `._version` file is missing.  This PR provides a minimal change that required to import with latest Jax version. Please let me know your thoughts!
 
Issue
---

The changes of this PR include:

### Importing `jax.config`

Since JAX 0.4.20, the following way to import `config` is deprecated. This can cause error for newer Jax version, and the current version fails to import 

```python
>>> import tornadox
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/stevenchiu/miniconda3/envs/numjax/lib/python3.11/site-packages/tornadox/__init__.py", line 3, in <module>
    from jax.config import config
ModuleNotFoundError: No module named 'jax.config'
```

### `._version` not found

Another issue is the `._version` is missing in the package. I simply removed this part to make the package imported without error. 

Suggestion 
---

As described in this PR, I did two thing in `__init__.py`

1. Change the way to import `jax.config`
2. Remove importing `._version`

Tested System
---

```
jax                       0.4.30                   pypi_0    pypi
jaxlib                    0.4.30                   pypi_0    pypi
```

Best,
Steven Chiu